### PR TITLE
tokio, reqwestのアップデート、clippy修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Cargo.lock
 #Cargo.lock
 
 build/
+.env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ include = [
 ]
 
 [dependencies]
-reqwest = { version = "0.10", features = ["json"] }
-tokio = { version = "0.2", features = ["full"] }
+reqwest = { version = "0.11.10", features = ["json"] }
+tokio = { version = "1.19.2", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1"

--- a/src/json.rs
+++ b/src/json.rs
@@ -128,7 +128,7 @@ mod tests {
     #[test]
     fn test_str_to_numbers() {
         let json_str = r#"{"i": "100", "f": "-10.55"}"#;
-        let json: Number = serde_json::from_str(&json_str).unwrap();
+        let json: Number = serde_json::from_str(json_str).unwrap();
         assert_eq!(json.i, 100);
         assert_eq!(json.f, -10.55);
     }
@@ -136,7 +136,7 @@ mod tests {
     #[test]
     fn test_str_to_datetime() {
         let json_str = r#"{"d": "2019-03-19T02:15:06.001Z"}"#;
-        let json: Date = serde_json::from_str(&json_str).unwrap();
+        let json: Date = serde_json::from_str(json_str).unwrap();
         assert_eq!(json.d.year(), 2019);
         assert_eq!(json.d.month(), 3);
         assert_eq!(json.d.day(), 19);

--- a/src/private.rs
+++ b/src/private.rs
@@ -87,7 +87,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
     /// * `order_ids` - 取得する注文の注文ID。最大10件まで指定できる。
     ///
     pub async fn orders(&self, order_ids: &[&str]) -> Result<RestResponse<Orders>, Error> {
-        let response = request_orders(&self.http_client, &order_ids).await?;
+        let response = request_orders(&self.http_client, order_ids).await?;
         Ok(response)
     }
 
@@ -102,7 +102,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         symbol: &Symbol,
     ) -> Result<RestResponse<ActiveOrders>, Error> {
         let response =
-            request_active_orders(&self.http_client, &symbol, DEFAULT_PAGE, DEFAULT_COUNT).await?;
+            request_active_orders(&self.http_client, symbol, DEFAULT_PAGE, DEFAULT_COUNT).await?;
         Ok(response)
     }
 
@@ -120,7 +120,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         page: i32,
         count: i32,
     ) -> Result<RestResponse<ActiveOrders>, Error> {
-        let response = request_active_orders(&self.http_client, &symbol, page, count).await?;
+        let response = request_active_orders(&self.http_client, symbol, page, count).await?;
         Ok(response)
     }
 
@@ -134,7 +134,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         &self,
         order_id: &str,
     ) -> Result<RestResponse<Executions>, Error> {
-        let response = request_executions_with_order_id(&self.http_client, &order_id).await?;
+        let response = request_executions_with_order_id(&self.http_client, order_id).await?;
         Ok(response)
     }
 
@@ -149,7 +149,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         execution_id: &str,
     ) -> Result<RestResponse<Executions>, Error> {
         let response =
-            request_executions_with_execution_id(&self.http_client, &execution_id).await?;
+            request_executions_with_execution_id(&self.http_client, execution_id).await?;
         Ok(response)
     }
 
@@ -164,7 +164,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         symbol: &Symbol,
     ) -> Result<RestResponse<LatestExecutions>, Error> {
         let response =
-            request_latest_executions(&self.http_client, &symbol, DEFAULT_PAGE, DEFAULT_COUNT)
+            request_latest_executions(&self.http_client, symbol, DEFAULT_PAGE, DEFAULT_COUNT)
                 .await?;
         Ok(response)
     }
@@ -183,7 +183,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         page: i32,
         count: i32,
     ) -> Result<RestResponse<LatestExecutions>, Error> {
-        let response = request_latest_executions(&self.http_client, &symbol, page, count).await?;
+        let response = request_latest_executions(&self.http_client, symbol, page, count).await?;
         Ok(response)
     }
 
@@ -200,7 +200,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         symbol: &Symbol,
     ) -> Result<RestResponse<OpenPositions>, Error> {
         let response =
-            request_open_positions(&self.http_client, &symbol, DEFAULT_PAGE, DEFAULT_COUNT).await?;
+            request_open_positions(&self.http_client, symbol, DEFAULT_PAGE, DEFAULT_COUNT).await?;
         Ok(response)
     }
 
@@ -218,7 +218,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         page: i32,
         count: i32,
     ) -> Result<RestResponse<OpenPositions>, Error> {
-        let response = request_open_positions(&self.http_client, &symbol, page, count).await?;
+        let response = request_open_positions(&self.http_client, symbol, page, count).await?;
         Ok(response)
     }
 
@@ -232,7 +232,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         &self,
         symbol: &Symbol,
     ) -> Result<RestResponse<PositionSummary>, Error> {
-        let response = request_position_summary(&self.http_client, &symbol).await?;
+        let response = request_position_summary(&self.http_client, symbol).await?;
         Ok(response)
     }
 
@@ -254,12 +254,12 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         size: f64,
         price: Option<i64>,
     ) -> Result<RestResponse<Order>, Error> {
-        let time_in_force = get_default_time_in_force(&execution_type);
+        let time_in_force = get_default_time_in_force(execution_type);
         let response = request_order(
             &self.http_client,
-            &execution_type,
-            &symbol,
-            &side,
+            execution_type,
+            symbol,
+            side,
             size,
             &time_in_force,
             price,
@@ -293,11 +293,11 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
     ) -> Result<RestResponse<Order>, Error> {
         let response = request_order(
             &self.http_client,
-            &execution_type,
-            &symbol,
-            &side,
+            execution_type,
+            symbol,
+            side,
             size,
-            &time_in_force,
+            time_in_force,
             price,
             losscut_price,
         )
@@ -317,7 +317,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         order_id: &str,
         price: i64,
     ) -> Result<RestResponse<ChangeOrder>, Error> {
-        let response = request_change_order(&self.http_client, &order_id, price, None).await?;
+        let response = request_change_order(&self.http_client, order_id, price, None).await?;
         Ok(response)
     }
 
@@ -336,7 +336,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         losscut_price: i64,
     ) -> Result<RestResponse<ChangeOrder>, Error> {
         let response =
-            request_change_order(&self.http_client, &order_id, price, Some(losscut_price)).await?;
+            request_change_order(&self.http_client, order_id, price, Some(losscut_price)).await?;
         Ok(response)
     }
 
@@ -347,7 +347,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
     /// * `order_id` - 注文ID。
     ///
     pub async fn cancel_order(&self, order_id: &str) -> Result<RestResponse<CancelOrder>, Error> {
-        let response = request_cancel_order(&self.http_client, &order_id).await?;
+        let response = request_cancel_order(&self.http_client, order_id).await?;
         Ok(response)
     }
 
@@ -361,7 +361,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         &self,
         order_ids: &[&str],
     ) -> Result<RestResponse<CancelOrders>, Error> {
-        let response = request_cancel_orders(&self.http_client, &order_ids).await?;
+        let response = request_cancel_orders(&self.http_client, order_ids).await?;
         Ok(response)
     }
 
@@ -376,7 +376,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         symbols: &[&Symbol],
     ) -> Result<RestResponse<CancelBulkOrder>, Error> {
         let response =
-            request_cancel_bulk_order(&self.http_client, &symbols, None, None, false).await?;
+            request_cancel_bulk_order(&self.http_client, symbols, None, None, false).await?;
         Ok(response)
     }
 
@@ -398,10 +398,10 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
     ) -> Result<RestResponse<CancelBulkOrder>, Error> {
         let response = match desc {
             Some(d) => {
-                request_cancel_bulk_order(&self.http_client, &symbols, side, settle_type, d).await?
+                request_cancel_bulk_order(&self.http_client, symbols, side, settle_type, d).await?
             }
             None => {
-                request_cancel_bulk_order(&self.http_client, &symbols, side, settle_type, false)
+                request_cancel_bulk_order(&self.http_client, symbols, side, settle_type, false)
                     .await?
             }
         };
@@ -428,15 +428,15 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         price: Option<i64>,
         position_id: &str,
     ) -> Result<RestResponse<CloseOrder>, Error> {
-        let time_in_force = get_default_time_in_force(&execution_type);
+        let time_in_force = get_default_time_in_force(execution_type);
         let response = request_close_order(
             &self.http_client,
-            &execution_type,
-            &symbol,
-            &side,
+            execution_type,
+            symbol,
+            side,
             size,
             price,
-            &position_id,
+            position_id,
             &time_in_force,
         )
         .await?;
@@ -467,13 +467,13 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
     ) -> Result<RestResponse<CloseOrder>, Error> {
         let response = request_close_order(
             &self.http_client,
-            &execution_type,
-            &symbol,
-            &side,
+            execution_type,
+            symbol,
+            side,
             size,
             price,
-            &position_id,
-            &time_in_force,
+            position_id,
+            time_in_force,
         )
         .await?;
         Ok(response)
@@ -497,12 +497,12 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         size: f64,
         price: Option<i64>,
     ) -> Result<RestResponse<CloseBulkOrder>, Error> {
-        let time_in_force = get_default_time_in_force(&execution_type);
+        let time_in_force = get_default_time_in_force(execution_type);
         let response = request_close_bulk_order(
             &self.http_client,
-            &execution_type,
-            &symbol,
-            &side,
+            execution_type,
+            symbol,
+            side,
             size,
             price,
             &time_in_force,
@@ -533,12 +533,12 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
     ) -> Result<RestResponse<CloseBulkOrder>, Error> {
         let response = request_close_bulk_order(
             &self.http_client,
-            &execution_type,
-            &symbol,
-            &side,
+            execution_type,
+            symbol,
+            side,
             size,
             price,
-            &time_in_force,
+            time_in_force,
         )
         .await?;
         Ok(response)
@@ -557,7 +557,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PrivateAPI<T> {
         losscut_price: i64,
     ) -> Result<RestResponse<ChangeLosscutPrice>, Error> {
         let response =
-            request_change_losscut_price(&self.http_client, &position_id, losscut_price).await?;
+            request_change_losscut_price(&self.http_client, position_id, losscut_price).await?;
         Ok(response)
     }
 }

--- a/src/private/active_orders.rs
+++ b/src/private/active_orders.rs
@@ -72,7 +72,7 @@ pub async fn request_active_orders(
         page,
         count,
     );
-    let headers = Headers::create_get_headers(&ACTIVE_ORDERS_API_PATH)?;
+    let headers = Headers::create_get_headers(ACTIVE_ORDERS_API_PATH)?;
     let response = http_client.get(url, &headers).await?;
     parse_from_http_response::<ActiveOrders>(&response)
 }

--- a/src/private/assets.rs
+++ b/src/private/assets.rs
@@ -69,7 +69,7 @@ impl RestResponse<Assets> {
 /// 資産残高APIを呼び出す。
 pub async fn request_assets(http_client: &impl HttpClient) -> Result<RestResponse<Assets>, Error> {
     let url = format!("{}{}", PRIVATE_ENDPOINT, ASSETS_API_PATH,);
-    let headers = Headers::create_get_headers(&ASSETS_API_PATH)?;
+    let headers = Headers::create_get_headers(ASSETS_API_PATH)?;
     let response = http_client.get(url, &headers).await?;
     parse_from_http_response::<Assets>(&response)
 }

--- a/src/private/cancel_bulk_order.rs
+++ b/src/private/cancel_bulk_order.rs
@@ -86,8 +86,8 @@ pub async fn request_cancel_bulk_order(
     desc: bool,
 ) -> Result<RestResponse<CancelBulkOrder>, Error> {
     let url = format!("{}{}", PRIVATE_ENDPOINT, CANCEL_BULK_ORDERS_API_PATH,);
-    let parameters = build_parameters(&symbols, side, settle_type, desc)?;
-    let headers = Headers::create_post_headers(&CANCEL_BULK_ORDERS_API_PATH, &parameters)?;
+    let parameters = build_parameters(symbols, side, settle_type, desc)?;
+    let headers = Headers::create_post_headers(CANCEL_BULK_ORDERS_API_PATH, &parameters)?;
     let response = http_client.post(url, &headers, &parameters).await?;
     parse_from_http_response::<CancelBulkOrder>(&response)
 }
@@ -116,7 +116,7 @@ mod tests {
         };
         let resp = request_cancel_bulk_order(
             &http_client,
-            &vec![&Symbol::Btc, &Symbol::EthJpy],
+            &[&Symbol::Btc, &Symbol::EthJpy],
             Some(&Side::Sell),
             None,
             false,

--- a/src/private/cancel_order.rs
+++ b/src/private/cancel_order.rs
@@ -25,7 +25,7 @@ pub struct CancelOrder {
 }
 
 fn build_parameters(order_id: &str) -> Result<Value, Error> {
-    let order_id_num = id_to_num(&order_id)?;
+    let order_id_num = id_to_num(order_id)?;
     Ok(json!({"orderId": order_id_num,}))
 }
 
@@ -36,7 +36,7 @@ pub async fn request_cancel_order(
 ) -> Result<RestResponse<CancelOrder>, Error> {
     let url = format!("{}{}", PRIVATE_ENDPOINT, CANCEL_ORDER_API_PATH,);
     let parameters = build_parameters(order_id)?;
-    let headers = Headers::create_post_headers(&CANCEL_ORDER_API_PATH, &parameters)?;
+    let headers = Headers::create_post_headers(CANCEL_ORDER_API_PATH, &parameters)?;
     let response = http_client.post(url, &headers, &parameters).await?;
     parse_from_http_response::<CancelOrder>(&response)
 }

--- a/src/private/cancel_orders.rs
+++ b/src/private/cancel_orders.rs
@@ -69,8 +69,8 @@ pub async fn request_cancel_orders(
     order_ids: &[&str],
 ) -> Result<RestResponse<CancelOrders>, Error> {
     let url = format!("{}{}", PRIVATE_ENDPOINT, CANCEL_ORDERS_API_PATH,);
-    let parameters = build_parameters(&order_ids)?;
-    let headers = Headers::create_post_headers(&CANCEL_ORDERS_API_PATH, &parameters)?;
+    let parameters = build_parameters(order_ids)?;
+    let headers = Headers::create_post_headers(CANCEL_ORDERS_API_PATH, &parameters)?;
     let response = http_client.post(url, &headers, &parameters).await?;
     parse_from_http_response::<CancelOrders>(&response)
 }
@@ -111,7 +111,7 @@ mod tests {
             body_text: body.to_string(),
             return_error: false,
         };
-        let resp = request_cancel_orders(&http_client, &vec!["1", "2", "3", "4"])
+        let resp = request_cancel_orders(&http_client, &["1", "2", "3", "4"])
             .await
             .unwrap();
         assert_eq!(resp.http_status_code, 200);

--- a/src/private/change_losscut_price.rs
+++ b/src/private/change_losscut_price.rs
@@ -38,8 +38,8 @@ pub async fn request_change_losscut_price(
     losscut_price: i64,
 ) -> Result<RestResponse<ChangeLosscutPrice>, Error> {
     let url = format!("{}{}", PRIVATE_ENDPOINT, CHANGE_LOSSCUT_PRICE_API_PATH,);
-    let parameters = build_parameters(&position_id, losscut_price);
-    let headers = Headers::create_post_headers(&CHANGE_LOSSCUT_PRICE_API_PATH, &parameters)?;
+    let parameters = build_parameters(position_id, losscut_price);
+    let headers = Headers::create_post_headers(CHANGE_LOSSCUT_PRICE_API_PATH, &parameters)?;
     let response = http_client.post(url, &headers, &parameters).await?;
     parse_from_http_response::<ChangeLosscutPrice>(&response)
 }

--- a/src/private/change_order.rs
+++ b/src/private/change_order.rs
@@ -29,7 +29,7 @@ fn build_parameters(
     price: i64,
     losscut_price: Option<i64>,
 ) -> Result<Value, Error> {
-    let order_id_num = id_to_num(&order_id)?;
+    let order_id_num = id_to_num(order_id)?;
     Ok(match losscut_price {
         Some(lp) => json!({
             "orderId": order_id_num,
@@ -52,7 +52,7 @@ pub async fn request_change_order(
 ) -> Result<RestResponse<ChangeOrder>, Error> {
     let url = format!("{}{}", PRIVATE_ENDPOINT, CHANGE_ORDER_API_PATH,);
     let parameters = build_parameters(order_id, price, losscut_price)?;
-    let headers = Headers::create_post_headers(&CHANGE_ORDER_API_PATH, &parameters)?;
+    let headers = Headers::create_post_headers(CHANGE_ORDER_API_PATH, &parameters)?;
     let response = http_client.post(url, &headers, &parameters).await?;
     parse_from_http_response::<ChangeOrder>(&response)
 }

--- a/src/private/close_bulk_order.rs
+++ b/src/private/close_bulk_order.rs
@@ -50,17 +50,12 @@ fn build_parameters(
 ) -> Result<Value, Error> {
     Ok(match execution_type {
         ExecutionType::Market => {
-            build_market_parameters(&execution_type, &symbol, &side, size, &time_in_force)?
+            build_market_parameters(execution_type, symbol, side, size, time_in_force)?
         }
         _ => match price {
-            Some(p) => build_limit_or_stop_paramters(
-                &execution_type,
-                &symbol,
-                &side,
-                size,
-                p,
-                &time_in_force,
-            )?,
+            Some(p) => {
+                build_limit_or_stop_paramters(execution_type, symbol, side, size, p, time_in_force)?
+            }
             None => return Err(Error::PriceNotSpecifiedError()),
         },
     })
@@ -111,9 +106,8 @@ pub async fn request_close_bulk_order(
     time_in_force: &TimeInForce,
 ) -> Result<RestResponse<CloseBulkOrder>, Error> {
     let url = format!("{}{}", PRIVATE_ENDPOINT, CLOSE_ORDER_API_PATH,);
-    let parameters =
-        build_parameters(&execution_type, &symbol, &side, size, price, &time_in_force)?;
-    let headers = Headers::create_post_headers(&CLOSE_ORDER_API_PATH, &parameters)?;
+    let parameters = build_parameters(execution_type, symbol, side, size, price, time_in_force)?;
+    let headers = Headers::create_post_headers(CLOSE_ORDER_API_PATH, &parameters)?;
     let response = http_client.post(url, &headers, &parameters).await?;
     parse_from_http_response::<CloseBulkOrder>(&response)
 }

--- a/src/private/close_order.rs
+++ b/src/private/close_order.rs
@@ -51,22 +51,22 @@ fn build_parameters(
 ) -> Result<Value, Error> {
     Ok(match execution_type {
         ExecutionType::Market => build_market_parameters(
-            &execution_type,
-            &symbol,
-            &side,
+            execution_type,
+            symbol,
+            side,
             size,
-            &position_id,
-            &time_in_force,
+            position_id,
+            time_in_force,
         )?,
         _ => match price {
             Some(p) => build_limit_or_stop_paramters(
-                &execution_type,
-                &symbol,
-                &side,
+                execution_type,
+                symbol,
+                side,
                 size,
                 p,
-                &position_id,
-                &time_in_force,
+                position_id,
+                time_in_force,
             )?,
             None => return Err(Error::PriceNotSpecifiedError()),
         },
@@ -88,7 +88,7 @@ fn build_market_parameters(
         "timeInForce": time_in_force.to_string(),
         "settlePosition": [
             {
-                "positionId": id_to_num(&position_id)?,
+                "positionId": id_to_num(position_id)?,
                 "size": size.to_string(),
             }
         ]
@@ -112,7 +112,7 @@ fn build_limit_or_stop_paramters(
         "price": price.to_string(),
         "settlePosition": [
             {
-                "positionId": id_to_num(&position_id)?,
+                "positionId": id_to_num(position_id)?,
                 "size": size.to_string(),
             }
         ]
@@ -132,15 +132,15 @@ pub async fn request_close_order(
 ) -> Result<RestResponse<CloseOrder>, Error> {
     let url = format!("{}{}", PRIVATE_ENDPOINT, CLOSE_ORDER_API_PATH,);
     let parameters = build_parameters(
-        &execution_type,
-        &symbol,
-        &side,
+        execution_type,
+        symbol,
+        side,
         size,
         price,
-        &position_id,
-        &time_in_force,
+        position_id,
+        time_in_force,
     )?;
-    let headers = Headers::create_post_headers(&CLOSE_ORDER_API_PATH, &parameters)?;
+    let headers = Headers::create_post_headers(CLOSE_ORDER_API_PATH, &parameters)?;
     let response = http_client.post(url, &headers, &parameters).await?;
     parse_from_http_response::<CloseOrder>(&response)
 }

--- a/src/private/executions.rs
+++ b/src/private/executions.rs
@@ -51,7 +51,7 @@ pub async fn request_executions_with_order_id(
         "{}{}?orderId={}",
         PRIVATE_ENDPOINT, EXECUTIONS_API_PATH, order_id,
     );
-    let headers = Headers::create_get_headers(&EXECUTIONS_API_PATH)?;
+    let headers = Headers::create_get_headers(EXECUTIONS_API_PATH)?;
     let response = http_client.get(url, &headers).await?;
     parse_from_http_response::<Executions>(&response)
 }
@@ -65,7 +65,7 @@ pub async fn request_executions_with_execution_id(
         "{}{}?executionId={}",
         PRIVATE_ENDPOINT, EXECUTIONS_API_PATH, execution_id,
     );
-    let headers = Headers::create_get_headers(&EXECUTIONS_API_PATH)?;
+    let headers = Headers::create_get_headers(EXECUTIONS_API_PATH)?;
     let response = http_client.get(url, &headers).await?;
     parse_from_http_response::<Executions>(&response)
 }

--- a/src/private/latest_executions.rs
+++ b/src/private/latest_executions.rs
@@ -72,7 +72,7 @@ pub async fn request_latest_executions(
         page,
         count
     );
-    let headers = Headers::create_get_headers(&LATEST_EXECUTIONS_API_PATH)?;
+    let headers = Headers::create_get_headers(LATEST_EXECUTIONS_API_PATH)?;
     let response = http_client.get(url, &headers).await?;
     parse_from_http_response::<LatestExecutions>(&response)
 }

--- a/src/private/margin.rs
+++ b/src/private/margin.rs
@@ -71,7 +71,7 @@ impl RestResponse<Margin> {
 /// 余力情報APIを呼び出す。
 pub async fn request_margin(http_client: &impl HttpClient) -> Result<RestResponse<Margin>, Error> {
     let url = format!("{}{}", PRIVATE_ENDPOINT, MARGIN_API_PATH);
-    let headers = Headers::create_get_headers(&MARGIN_API_PATH)?;
+    let headers = Headers::create_get_headers(MARGIN_API_PATH)?;
     let response = http_client.get(url, &headers).await?;
     parse_from_http_response::<Margin>(&response)
 }

--- a/src/private/open_positions.rs
+++ b/src/private/open_positions.rs
@@ -72,7 +72,7 @@ pub async fn request_open_positions(
         page,
         count,
     );
-    let headers = Headers::create_get_headers(&OPEN_POSITIONS_API_PATH)?;
+    let headers = Headers::create_get_headers(OPEN_POSITIONS_API_PATH)?;
     let response = http_client.get(url, &headers).await?;
     parse_from_http_response::<OpenPositions>(&response)
 }

--- a/src/private/order.rs
+++ b/src/private/order.rs
@@ -51,15 +51,15 @@ fn build_parameters(
 ) -> Result<Value, Error> {
     Ok(match execution_type {
         ExecutionType::Market => {
-            build_market_parameters(&execution_type, &symbol, &side, size, &time_in_force)
+            build_market_parameters(execution_type, symbol, side, size, time_in_force)
         }
         _ => match price {
             Some(p) => build_limit_or_stop_paramters(
-                &execution_type,
-                &symbol,
-                &side,
+                execution_type,
+                symbol,
+                side,
                 size,
-                &time_in_force,
+                time_in_force,
                 p,
                 losscut_price,
             ),
@@ -127,15 +127,15 @@ pub async fn request_order(
 ) -> Result<RestResponse<Order>, Error> {
     let url = format!("{}{}", PRIVATE_ENDPOINT, ORDER_API_PATH,);
     let parameters = build_parameters(
-        &execution_type,
-        &symbol,
-        &side,
+        execution_type,
+        symbol,
+        side,
         size,
-        &time_in_force,
+        time_in_force,
         price,
         losscut_price,
     )?;
-    let headers = Headers::create_post_headers(&ORDER_API_PATH, &parameters)?;
+    let headers = Headers::create_post_headers(ORDER_API_PATH, &parameters)?;
     let response = http_client.post(url, &headers, &parameters).await?;
     parse_from_http_response::<Order>(&response)
 }

--- a/src/private/orders.rs
+++ b/src/private/orders.rs
@@ -53,7 +53,7 @@ pub async fn request_orders(
         ORDERS_API_PATH,
         order_ids.join(",")
     );
-    let headers = Headers::create_get_headers(&ORDERS_API_PATH)?;
+    let headers = Headers::create_get_headers(ORDERS_API_PATH)?;
     let response = http_client.get(url, &headers).await?;
     parse_from_http_response::<Orders>(&response)
 }

--- a/src/private/position_summary.rs
+++ b/src/private/position_summary.rs
@@ -54,7 +54,7 @@ pub async fn request_position_summary(
         POSITION_SUMMARY_API_PATH,
         symbol.to_string(),
     );
-    let headers = Headers::create_get_headers(&POSITION_SUMMARY_API_PATH)?;
+    let headers = Headers::create_get_headers(POSITION_SUMMARY_API_PATH)?;
     let response = http_client.get(url, &headers).await?;
     parse_from_http_response::<PositionSummary>(&response)
 }

--- a/src/public.rs
+++ b/src/public.rs
@@ -37,7 +37,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PublicAPI<T> {
     /// * `symbol` - 銘柄
     ///
     pub async fn ticker(&self, symbol: &Symbol) -> Result<RestResponse<Ticker>, Error> {
-        let response = request_ticker(&self.http_client, &symbol).await?;
+        let response = request_ticker(&self.http_client, symbol).await?;
         Ok(response)
     }
 
@@ -48,7 +48,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PublicAPI<T> {
     /// * `symbol` - 銘柄
     ///
     pub async fn orderbooks(&self, symbol: &Symbol) -> Result<RestResponse<Orderbooks>, Error> {
-        let response = request_orderbooks(&self.http_client, &symbol).await?;
+        let response = request_orderbooks(&self.http_client, symbol).await?;
         Ok(response)
     }
 
@@ -60,7 +60,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PublicAPI<T> {
     ///
     pub async fn trades(&self, symbol: &Symbol) -> Result<RestResponse<Trades>, Error> {
         let response =
-            request_trades(&self.http_client, &symbol, DEFAULT_PAGE, DEFAULT_COUNT).await?;
+            request_trades(&self.http_client, symbol, DEFAULT_PAGE, DEFAULT_COUNT).await?;
         Ok(response)
     }
 
@@ -78,7 +78,7 @@ impl<T: HttpClient + std::marker::Sync + std::marker::Send> PublicAPI<T> {
         page: i32,
         count: i32,
     ) -> Result<RestResponse<Trades>, Error> {
-        let response = request_trades(&self.http_client, &symbol, page, count).await?;
+        let response = request_trades(&self.http_client, symbol, page, count).await?;
         Ok(response)
     }
 }

--- a/src/public/status.rs
+++ b/src/public/status.rs
@@ -118,7 +118,7 @@ mod tests {
             return_error: false,
         };
         let resp = request_status(&http_client).await;
-        assert_eq!(resp.is_err(), true);
+        assert!(resp.is_err());
     }
 
     #[tokio::test]
@@ -130,6 +130,6 @@ mod tests {
             return_error: true,
         };
         let resp = request_status(&http_client).await;
-        assert_eq!(resp.is_err(), true);
+        assert!(resp.is_err());
     }
 }


### PR DESCRIPTION
## やったこと
- .gitignoreに `.env` を追加
- tokio, reqwestがだいぶ古くなっていたのでアップデート
- clippyがwaning出してたので、それを全て修正

お手数ですが、こちらの修正を確認していただけないでしょうか？
よろしくお願いいたします :pray:

## refs
- #3 はmainブランチで出してしまったので修正して、こちらで出させていただきました。